### PR TITLE
Add directory tree and docker cleanup

### DIFF
--- a/src/cleaner.cpp
+++ b/src/cleaner.cpp
@@ -3,6 +3,7 @@
 #include "utils.h"
 
 #include <filesystem>
+#include <system_error>
 #include <thread>
 #include <vector>
 #include <algorithm>
@@ -34,17 +35,31 @@ void Cleaner::buildTargetPaths() {
             "C:\\Windows\\Temp",
             "C:\\Windows\\Prefetch"
         };
+        std::vector<std::string> dockerWin = {
+            "%USERPROFILE%\\.docker",
+            "C:\\ProgramData\\DockerDesktop"
+        };
         for (auto p : winPaths) {
             if (config.wsl) {
                 p = transformPathForWSL(p);
             }
+            p = expandPath(p);
+            if (p.empty() || p.find('%') != std::string::npos) continue;
+            targetPaths.push_back(p);
+        }
+        for (auto p : dockerWin) {
+            if (config.wsl) p = transformPathForWSL(p);
+            p = expandPath(p);
+            if (p.empty() || p.find('%') != std::string::npos) continue;
             targetPaths.push_back(p);
         }
     }
-    
+
     if (config.targetOS == OS_TYPE::LINUX || config.targetOS == OS_TYPE::AUTO) {
         targetPaths.push_back("/tmp");
         targetPaths.push_back("/var/tmp");
+        targetPaths.push_back(expandPath("~/.docker"));
+        targetPaths.push_back("/var/lib/docker");
     }
     
     if (config.cleanWindows) {
@@ -57,12 +72,16 @@ void Cleaner::buildTargetPaths() {
             if (config.wsl) {
                 p = transformPathForWSL(p);
             }
+            p = expandPath(p);
+            if (p.empty() || p.find('%') != std::string::npos) continue;
             targetPaths.push_back(p);
         }
     }
     
     for (const auto &path : config.additionalPaths) {
-        targetPaths.push_back(path);
+        std::string p = expandPath(path);
+        if (p.empty() || p.find('%') != std::string::npos) continue;
+        targetPaths.push_back(p);
     }
 }
 
@@ -76,15 +95,22 @@ std::tuple<size_t, size_t, double> Cleaner::countItemsToDelete() {
         if (path.find("systemd-private") != std::string::npos) continue;
 
         try {
-            for (auto &entry : fs::recursive_directory_iterator(path)) {
-                if (!config.includeHidden && entry.path().filename().string().front() == '.')
+            for (auto it = fs::recursive_directory_iterator(
+                         path, fs::directory_options::skip_permission_denied);
+                 it != fs::recursive_directory_iterator(); ++it) {
+                const fs::path &p = it->path();
+                if (p.string().find("systemd-private") != std::string::npos) {
+                    it.disable_recursion_pending();
+                    continue;
+                }
+                if (!config.includeHidden && p.filename().string().front() == '.')
                     continue;
 
-                if (entry.is_directory()) {
+                if (it->is_directory()) {
                     dirCount++;
-                } else if (entry.is_regular_file()) {
+                } else if (it->is_regular_file()) {
                     fileCount++;
-                    totalSize += entry.file_size();
+                    totalSize += it->file_size();
                 }
             }
         } catch (const fs::filesystem_error &e) {
@@ -123,13 +149,23 @@ void Cleaner::processPath(const std::string &path) {
     }
     
     try {
-        for (auto &entry : fs::recursive_directory_iterator(path)) {
-            std::string entryPath = entry.path().string();
-            // Фильтруем скрытые файлы, если соответствующий флаг не включён
-            if (!config.includeHidden && entry.path().filename().string().front() == '.')
+        std::vector<fs::path> entries;
+        for (auto it = fs::recursive_directory_iterator(
+                     path, fs::directory_options::skip_permission_denied);
+             it != fs::recursive_directory_iterator(); ++it) {
+            const fs::path &p = it->path();
+            if (p.string().find("systemd-private") != std::string::npos) {
+                it.disable_recursion_pending();
                 continue;
-            
-            // В режиме dry-run выводим, что будет удалено, иначе производим удаление
+            }
+            if (!config.includeHidden && p.filename().string().front() == '.')
+                continue;
+
+            entries.push_back(p);
+        }
+
+        for (auto it = entries.rbegin(); it != entries.rend(); ++it) {
+            std::string entryPath = it->string();
             if (config.dryRun) {
                 LOG_INFO("[Dry Run] Будет удалено: " + entryPath);
             } else {
@@ -149,13 +185,44 @@ void Cleaner::processPath(const std::string &path) {
 
 /// Удаление файла или директории
 void Cleaner::deleteEntry(const std::string &path) {
-    try {
-        if (fs::is_directory(path))
-            fs::remove_all(path);
-        else
-            fs::remove(path);
+    std::error_code ec;
+    if (fs::is_directory(path))
+        fs::remove_all(path, ec);
+    else
+        fs::remove(path, ec);
+
+    if (ec) {
+        LOG_WARNING("Ошибка удаления " + path + ": " + ec.message());
+    } else {
         LOG_INFO("Удалено: " + path);
-    } catch (const fs::filesystem_error &e) {
-        LOG_ERROR("Ошибка удаления " + path + ": " + e.what());
+    }
+}
+
+/// Распечатка дерева директорий с указанием их размера
+void Cleaner::printSizeTree() {
+    LOG_INFO("Размер целевых директорий:");
+    for (const auto &path : targetPaths) {
+        if (!pathExists(path)) continue;
+        auto size = directorySize(path);
+        LOG_INFO(path + " - " +
+                 std::to_string(static_cast<double>(size) / (1024 * 1024)) +
+                 " MB");
+        printSubTree(path, 1);
+    }
+}
+
+void Cleaner::printSubTree(const std::string &path, int level) {
+    for (auto it = fs::directory_iterator(path, fs::directory_options::skip_permission_denied);
+         it != fs::directory_iterator(); ++it) {
+        const fs::path &p = it->path();
+        if (!it->is_directory()) continue;
+        if (p.string().find("systemd-private") != std::string::npos) continue;
+        if (!config.includeHidden && p.filename().string().front() == '.') continue;
+
+        auto size = directorySize(p);
+        LOG_INFO(std::string(level * 2, ' ') + p.filename().string() + " - " +
+                 std::to_string(static_cast<double>(size) / (1024 * 1024)) +
+                 " MB");
+        if (level < 2) printSubTree(p.string(), level + 1);
     }
 }

--- a/src/cleaner.h
+++ b/src/cleaner.h
@@ -16,6 +16,9 @@ public:
 
     /// Подсчет количества файлов, папок и общего размера перед удалением
     std::tuple<size_t, size_t, double> countItemsToDelete();
+
+    /// Печать дерева директорий с их размерами
+    void printSizeTree();
     
 private:
     Config config;
@@ -29,6 +32,8 @@ private:
     
     /// Удаление файла или директории (с учётом dry-run)
     void deleteEntry(const std::string &path);
+
+    void printSubTree(const std::string &path, int level);
 };
 
 #endif // CLEANER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,6 +51,8 @@ int main(int argc, char* argv[]) {
     LOG_INFO("Папок: " + std::to_string(numDirs));
     LOG_INFO("Общий размер: " + std::to_string(totalSize) + " MB");
 
+    cleaner.printSizeTree();
+
     // Запрашиваем подтверждение от пользователя перед удалением
     std::string confirmation;
     std::cout << "Вы уверены, что хотите продолжить удаление? (y/n): ";

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,20 +1,60 @@
 #include "utils.h"
 #include <filesystem>
 #include <vector>
+#include <cstdlib>
 
 namespace fs = std::filesystem;
 
+/// Разворачиваем переменные окружения вида %VAR% и тильду
+std::string expandPath(const std::string &path) {
+    std::string result;
+    for (size_t i = 0; i < path.size(); ) {
+        if (path[i] == '%' && path.find('%', i + 1) != std::string::npos) {
+            size_t end = path.find('%', i + 1);
+            std::string var = path.substr(i + 1, end - i - 1);
+            const char *val = std::getenv(var.c_str());
+            if (val)
+                result += val;
+            else
+                result += "%" + var + "%";
+            i = end + 1;
+            continue;
+        }
+        if (path[i] == '~' && (i == 0 || path[i-1] == '/')) {
+            const char *home = std::getenv("HOME");
+            if (home) result += home;
+            ++i;
+            continue;
+        }
+        result += path[i++];
+    }
+    return result;
+}
+
 bool pathExists(const std::string &path) {
-    // Заметим: если используются переменные окружения, их можно разворачивать отдельно
-    return fs::exists(path);
+    return fs::exists(expandPath(path));
 }
 
 std::vector<fs::path> listFiles(const std::string &directory) {
     std::vector<fs::path> files;
-    if (!fs::exists(directory)) return files;
-    
-    for (const auto &entry : fs::directory_iterator(directory)) {
+    std::string dir = expandPath(directory);
+    if (!fs::exists(dir)) return files;
+
+    for (const auto &entry : fs::directory_iterator(dir)) {
         files.push_back(entry.path());
     }
     return files;
+}
+
+std::uintmax_t directorySize(const fs::path &path) {
+    std::uintmax_t size = 0;
+    for (auto it = fs::recursive_directory_iterator(
+                 path, fs::directory_options::skip_permission_denied);
+         it != fs::recursive_directory_iterator(); ++it) {
+        std::error_code ec;
+        if (it->is_regular_file(ec)) {
+            size += it->file_size(ec);
+        }
+    }
+    return size;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -5,10 +5,16 @@
 #include <vector>
 #include <filesystem>
 
+/// Разворачивание переменных окружения и тильды в пути
+std::string expandPath(const std::string &path);
+
 /// Проверка существования файла или директории
 bool pathExists(const std::string &path);
 
 /// Получение списка файлов в заданной директории
 std::vector<std::filesystem::path> listFiles(const std::string &directory);
+
+/// Подсчёт размера директории (в байтах)
+std::uintmax_t directorySize(const std::filesystem::path &path);
 
 #endif // UTILS_H


### PR DESCRIPTION
## Summary
- expand environment variables in paths
- compute directory sizes and print tree
- include Docker paths in cleanup
- show directory tree before confirmation

## Testing
- `./build.sh`
- `bin/cleaner --verbose --dry-run` (with interactive confirmation)

------
https://chatgpt.com/codex/tasks/task_e_68494f5250d08322acd92c69fe795f71