### PR TITLE
Add Windows build script and cleanup improvements

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,13 @@
+@echo off
+set OUTPUT_EXECUTABLE=cleaner.exe
+set BUILD_DIR=build
+set INSTALL_DIR=bin
+if not exist %BUILD_DIR% mkdir %BUILD_DIR%
+cd %BUILD_DIR%
+cmake .. -G "MinGW Makefiles" && cmake --build . --config Release || exit /b 1
+if not exist ..\%INSTALL_DIR% mkdir ..\%INSTALL_DIR%
+copy /Y Release\%OUTPUT_EXECUTABLE% ..\%INSTALL_DIR%\ >nul
+cd ..
+rmdir /S /Q %BUILD_DIR%
+@echo Build finished. Executable located at %INSTALL_DIR%\%OUTPUT_EXECUTABLE%
+

--- a/configs/basic.cfg
+++ b/configs/basic.cfg
@@ -61,6 +61,7 @@ old_logs = /var/log/*.log.1, /var/log/*.gz
 
 ; --- Кэш пользователя ---
 user_cache = ~/.cache
+downloads = ~/Downloads
 
 ; --- Docker ---
 docker_cache = ~/.docker/cache

--- a/src/cleaner.cpp
+++ b/src/cleaner.cpp
@@ -35,6 +35,9 @@ void Cleaner::buildTargetPaths() {
             "C:\\Windows\\Temp",
             "C:\\Windows\\Prefetch"
         };
+        std::vector<std::string> userWinPaths = {
+            "%USERPROFILE%\\Downloads"
+        };
         std::vector<std::string> dockerWin = {
             "%USERPROFILE%\\.docker",
             "C:\\ProgramData\\DockerDesktop"
@@ -43,6 +46,12 @@ void Cleaner::buildTargetPaths() {
             if (config.wsl) {
                 p = transformPathForWSL(p);
             }
+            p = expandPath(p);
+            if (p.empty() || p.find('%') != std::string::npos) continue;
+            targetPaths.push_back(p);
+        }
+        for (auto p : userWinPaths) {
+            if (config.wsl) p = transformPathForWSL(p);
             p = expandPath(p);
             if (p.empty() || p.find('%') != std::string::npos) continue;
             targetPaths.push_back(p);
@@ -60,6 +69,7 @@ void Cleaner::buildTargetPaths() {
         targetPaths.push_back("/var/tmp");
         targetPaths.push_back(expandPath("~/.docker"));
         targetPaths.push_back("/var/lib/docker");
+        targetPaths.push_back(expandPath("~/Downloads"));
     }
     
     if (config.cleanWindows) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,13 @@
 #include "config.h"
 #include "logger.h"
 #include "cleaner.h"
+#include "utils.h"
 
 #include <iostream>
 #include <fstream>
 #include <tuple>
+#include <filesystem>
+#include <vector>
 
 // Функция для вывода пиксель-арта
 void printPixelArt(const std::string& filePath) {
@@ -17,6 +20,76 @@ void printPixelArt(const std::string& filePath) {
     std::string line;
     while (std::getline(artFile, line)) {
         std::cout << line << std::endl;
+    }
+}
+
+namespace fs = std::filesystem;
+
+static std::vector<std::string> getPythonEnvRoots() {
+    std::vector<std::string> roots;
+#ifdef _WIN32
+    roots = {
+        "%USERPROFILE%\\.virtualenvs",
+        "%USERPROFILE%\\Anaconda3\\envs",
+        "%USERPROFILE%\\Miniconda3\\envs",
+        "%USERPROFILE%\\.conda\\envs"
+    };
+#else
+    roots = {
+        "~/.virtualenvs",
+        "~/anaconda3/envs",
+        "~/miniconda3/envs",
+        "~/.conda/envs",
+        "~/.pyenv/versions"
+    };
+#endif
+    return roots;
+}
+
+static std::vector<std::string> findPythonEnvironments() {
+    std::vector<std::string> envs;
+    for (auto r : getPythonEnvRoots()) {
+        r = expandPath(r);
+        if (!fs::exists(r)) continue;
+        for (const auto &entry : fs::directory_iterator(r)) {
+            if (entry.is_directory()) envs.push_back(entry.path().string());
+        }
+    }
+    return envs;
+}
+
+static void handlePythonEnvironments(const Config &config) {
+    LOG_INFO("Проверка Python-окружений...");
+    const double threshold = 3.0; // GB
+    for (const auto &env : findPythonEnvironments()) {
+        auto size = directorySize(env);
+        double sizeGb = static_cast<double>(size) / (1024 * 1024 * 1024);
+        if (sizeGb < threshold) continue;
+
+        std::cout << "Обнаружено Python окружение: " << env
+                  << " (" << sizeGb << " GB). Удалить? (y/n): ";
+        std::string ans;
+        std::getline(std::cin, ans);
+        if (ans == "y" || ans == "Y") {
+            if (config.dryRun) {
+                LOG_INFO("[Dry Run] Будет удалено окружение: " + env);
+            } else {
+                std::error_code ec;
+                fs::remove_all(env, ec);
+                if (ec)
+                    LOG_WARNING("Ошибка удаления " + env + ": " + ec.message());
+                else
+                    LOG_INFO("Удалено окружение: " + env);
+            }
+        }
+    }
+}
+
+static void pruneDockerImages() {
+    LOG_INFO("Запуск docker image prune...");
+    int code = std::system("docker image prune -a -f > /dev/null 2>&1");
+    if (code != 0) {
+        LOG_WARNING("Не удалось выполнить docker image prune");
     }
 }
 
@@ -65,7 +138,11 @@ int main(int argc, char* argv[]) {
     } else {
         LOG_INFO("Очистка отменена пользователем.");
     }
-    
+
+    // Дополнительные действия
+    handlePythonEnvironments(config);
+    pruneDockerImages();
+
     LOG_INFO("Работа утилиты завершена");
     return 0;
 }


### PR DESCRIPTION
## Summary
- add `build.bat` for Windows builds
- include Downloads folders in cleanup targets
- detect big Python environments and offer to delete them
- run Docker image prune after cleanup
- update default config with Linux Downloads path

## Testing
- `bash build.sh`


------
https://chatgpt.com/codex/tasks/task_e_684959831fd48322addcd917e03684bb